### PR TITLE
Adding cw-orchestrator to the minimal template

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,8 +51,9 @@ schemars = "0.8.8"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.31" }
 
-cw-orch = { version = "0.18.1", optional = true }
+cw-orch = { version = "0.19.1", optional = true }
 
 [dev-dependencies]
-cw-multi-test = "0.13.2"
+
 {{project-name}} = {path = ".", features=["interface"]}
+cw-multi-test = "0.13.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ overflow-checks = true
 backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all instantiate/execute/query exports
 library = []
+# use interface feature to expose structure for contract orchestration
+interface = ["dep:cw-orch"]
 
 [package.metadata.scripts]
 optimize = """docker run --rm -v "$(pwd)":/code \
@@ -49,5 +51,8 @@ schemars = "0.8.8"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.31" }
 
+cw-orch = { version = "0.18.1", optional = true }
+
 [dev-dependencies]
 cw-multi-test = "0.13.2"
+{{project-name}} = {path = ".", features=["interface"]}

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,0 +1,23 @@
+use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use cosmwasm_std::Empty;
+use cw_orch::{interface, prelude::*};
+
+#[interface(InstantiateMsg, ExecuteMsg, QueryMsg, Empty)]
+pub struct ContractInterface;
+
+impl<Chain: CwEnv> Uploadable for ContractInterface<Chain> {
+    /// Return the path to the wasm file corresponding to the contract
+    fn wasm(&self) -> WasmPath {
+        artifacts_dir_from_workspace!()
+            .find_wasm_path("{{crate_name}}")
+            .unwrap()
+    }
+    /// Returns a CosmWasm contract wrapper
+    fn wrapper(&self) -> Box<dyn MockContract<Empty>> {
+        Box::new(ContractWrapper::new_with_empty(
+            crate::contract::execute,
+            crate::contract::instantiate,
+            crate::contract::query,
+        ))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,6 @@ pub mod msg;
 pub mod state;
 
 pub use crate::error::ContractError;
+
+#[cfg(feature = "interface")]
+pub mod interface;

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -6,6 +6,7 @@ pub struct InstantiateMsg {}
 
 /// Message type for `execute` entry_point
 #[cw_serde]
+#[cfg_attr(feature = "interface", derive(cw_orch::ExecuteFns))]
 pub enum ExecuteMsg {}
 
 /// Message type for `migrate` entry_point
@@ -15,6 +16,7 @@ pub enum MigrateMsg {}
 /// Message type for `query` entry_point
 #[cw_serde]
 #[derive(QueryResponses)]
+#[cfg_attr(feature = "interface", derive(cw_orch::QueryFns))]
 pub enum QueryMsg {
     // This example query variant indicates that any client can query the contract
     // using `YourQuery` and it will return `YourQueryResponse`


### PR DESCRIPTION
This PR aims at adding cw-orchestrator directly into the minimal cw-template. 

You can find the docs for this library here : https://orchestrator.abstract.money/

This library empowers users with their smart-contracts and allows them to script, test and more using a single intuitive syntax and without leaving the Rust programming language.

With this template, cw-orch integration has never been easier. The generated interface is available directly inside the template tests. An example test syntax can be found in the `src/interface.rs` file.

